### PR TITLE
feat: Crear producto en intranet al publicar en catalog-publish

### DIFF
--- a/controllers/catalogController.js
+++ b/controllers/catalogController.js
@@ -3,6 +3,9 @@ const AsinCatalogMapping = require('../models/asinCatalogMapping');
 const { meliRequest } = require('../config/meliconfig');
 const logger = require('../config/logger');
 
+const INVENTORY_APP_URL = process.env.INVENTORY_APP_URL || 'https://inventory-app-713792767554.us-central1.run.app';
+const INVENTORY_API_KEY = process.env.INVENTORY_API_KEY || '';
+
 // Dimensiones por defecto del paquete (17x14x14 cm, 1 kg)
 const DEFAULT_DIMENSIONS = {
     height: 17,
@@ -113,6 +116,77 @@ const fetchLatestSaleCommission = async (categoryId, priceForQuery, fallbackComm
     }
 
     return commission;
+};
+
+const createProductInIntranet = async (catalogMapping, sku, itemId, title, dimensions) => {
+    // Paso 1: Crear producto
+    const productPayload = {
+        sku,
+        title,
+        asin: catalogMapping.asin,
+        mlm: itemId,
+        upc: catalogMapping.catalogIdentifier,
+        img: catalogMapping.image,
+        current_cost: catalogMapping.amazonPrice,
+        packageLength: dimensions.length,
+        packageWidth: dimensions.width,
+        packageHeight: dimensions.height,
+        packageWeight: dimensions.weight / 1000,
+        isActive: true
+    };
+
+    const createRes = await fetch(`${INVENTORY_APP_URL}/api/products`, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            'x-api-key': INVENTORY_API_KEY
+        },
+        body: JSON.stringify(productPayload)
+    });
+
+    if (createRes.status === 409) {
+        logger.info(`Producto ${sku} ya existe en intranet (409), continuando.`);
+    } else if (!createRes.ok) {
+        const errorBody = await createRes.text();
+        throw new Error(`Error creando producto en intranet (${createRes.status}): ${errorBody}`);
+    } else {
+        logger.info(`Producto ${sku} creado en intranet exitosamente.`);
+    }
+
+    // Paso 2: Agregar barcodes alternos
+    if (Array.isArray(catalogMapping.identifiers) && catalogMapping.identifiers.length > 0) {
+        for (const identifier of catalogMapping.identifiers) {
+            try {
+                const barcodeRes = await fetch(`${INVENTORY_APP_URL}/api/products/${sku}/alternate-barcodes`, {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'x-api-key': INVENTORY_API_KEY
+                    },
+                    body: JSON.stringify({
+                        barcode: identifier,
+                        type: 'ean',
+                        addedBy: 'info@guatevermexico.com',
+                        source: 'sync-catalog-publish'
+                    })
+                });
+                if (!barcodeRes.ok) {
+                    logger.warn(`No se pudo agregar barcode ${identifier} para ${sku}: ${barcodeRes.status}`);
+                }
+            } catch (err) {
+                logger.warn(`Error agregando barcode ${identifier} para ${sku}: ${err.message}`);
+            }
+        }
+    }
+};
+
+const closeMeliPublication = async (itemId) => {
+    try {
+        await meliRequest(`items/${itemId}`, 'PUT', { status: 'closed' });
+        logger.info(`Publicación ${itemId} cerrada (rollback).`);
+    } catch (err) {
+        logger.error(`Error al cerrar publicación ${itemId} durante rollback: ${err.message}`);
+    }
 };
 
 /**
@@ -324,6 +398,18 @@ const publishToCatalog = async (req, res) => {
 
         logger.info(`Publicación creada exitosamente. ItemId: ${itemId}`);
 
+        // Crear producto en intranet (sync-inventory)
+        try {
+            await createProductInIntranet(catalogMapping, sku, itemId, title, dimensions);
+        } catch (intranetError) {
+            logger.error(`Error creando producto en intranet para SKU ${sku}: ${intranetError.message}`);
+            await closeMeliPublication(itemId);
+            return res.status(500).json({
+                success: false,
+                error: `Producto publicado en ML pero falló la creación en intranet. Se cerró la publicación ${itemId}. Detalle: ${intranetError.message}`
+            });
+        }
+
         const updatedShippingCost = latestShippingCost;
         const updatedSaleCommission = latestSaleCommission;
 
@@ -367,7 +453,8 @@ const publishToCatalog = async (req, res) => {
                 title: title || 'Título del producto',
                 mlShippingCost: updatedShippingCost,
                 mlSaleCommission: updatedSaleCommission,
-                permalink: permalink
+                permalink: permalink,
+                intranetProductCreated: true
             }
         };
 

--- a/controllers/catalogController.js
+++ b/controllers/catalogController.js
@@ -118,6 +118,15 @@ const fetchLatestSaleCommission = async (categoryId, priceForQuery, fallbackComm
     return commission;
 };
 
+const MAX_INTRANET_RETRIES = 3;
+const INTRANET_RETRY_DELAY_MS = 1000;
+
+const isTransientError = (error, response) => {
+    if (!response) return true; // Error de red (timeout, DNS, conexión rechazada)
+    const status = response.status;
+    return status >= 500 || status === 429;
+};
+
 const createProductInIntranet = async (catalogMapping, sku, itemId, title, dimensions) => {
     // Paso 1: Crear producto
     const productPayload = {
@@ -135,22 +144,44 @@ const createProductInIntranet = async (catalogMapping, sku, itemId, title, dimen
         isActive: true
     };
 
-    const createRes = await fetch(`${INVENTORY_APP_URL}/api/products`, {
-        method: 'POST',
-        headers: {
-            'Content-Type': 'application/json',
-            'x-api-key': INVENTORY_API_KEY
-        },
-        body: JSON.stringify(productPayload)
-    });
+    let lastError;
+    for (let attempt = 1; attempt <= MAX_INTRANET_RETRIES; attempt++) {
+        let createRes;
+        try {
+            createRes = await fetch(`${INVENTORY_APP_URL}/api/products`, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'x-api-key': INVENTORY_API_KEY
+                },
+                body: JSON.stringify(productPayload)
+            });
+        } catch (networkError) {
+            lastError = networkError;
+            if (attempt < MAX_INTRANET_RETRIES) {
+                logger.warn(`Intento ${attempt}/${MAX_INTRANET_RETRIES} falló por error de red para ${sku}: ${networkError.message}. Reintentando...`);
+                await new Promise(r => setTimeout(r, INTRANET_RETRY_DELAY_MS * attempt));
+                continue;
+            }
+            throw new Error(`Error de red creando producto en intranet tras ${MAX_INTRANET_RETRIES} intentos: ${networkError.message}`);
+        }
 
-    if (createRes.status === 409) {
-        logger.info(`Producto ${sku} ya existe en intranet (409), continuando.`);
-    } else if (!createRes.ok) {
-        const errorBody = await createRes.text();
-        throw new Error(`Error creando producto en intranet (${createRes.status}): ${errorBody}`);
-    } else {
-        logger.info(`Producto ${sku} creado en intranet exitosamente.`);
+        if (createRes.status === 409) {
+            logger.info(`Producto ${sku} ya existe en intranet (409), continuando.`);
+            break;
+        } else if (!createRes.ok) {
+            const errorBody = await createRes.text();
+            lastError = new Error(`Error creando producto en intranet (${createRes.status}): ${errorBody}`);
+            if (isTransientError(null, createRes) && attempt < MAX_INTRANET_RETRIES) {
+                logger.warn(`Intento ${attempt}/${MAX_INTRANET_RETRIES} falló (${createRes.status}) para ${sku}. Reintentando...`);
+                await new Promise(r => setTimeout(r, INTRANET_RETRY_DELAY_MS * attempt));
+                continue;
+            }
+            throw lastError;
+        } else {
+            logger.info(`Producto ${sku} creado en intranet exitosamente.`);
+            break;
+        }
     }
 
     // Paso 2: Agregar barcodes alternos
@@ -333,6 +364,9 @@ const publishToCatalog = async (req, res) => {
         logger.info('Enviando solicitud a MercadoLibre API');
         logger.info('Payload:', JSON.stringify(payload, null, 2));
 
+        // Guardar dimensiones originales antes del retry (el retry las infla para ML)
+        const originalDimensions = { ...dimensions };
+
         // Realizar la publicación en MercadoLibre con retry para dimensiones
         let response = await meliRequest('items', 'POST', payload);
         let dimensionRetries = 0;
@@ -400,7 +434,7 @@ const publishToCatalog = async (req, res) => {
 
         // Crear producto en intranet (sync-inventory)
         try {
-            await createProductInIntranet(catalogMapping, sku, itemId, title, dimensions);
+            await createProductInIntranet(catalogMapping, sku, itemId, title, originalDimensions);
         } catch (intranetError) {
             logger.error(`Error creando producto en intranet para SKU ${sku}: ${intranetError.message}`);
             await closeMeliPublication(itemId);

--- a/controllers/notificationsController.js
+++ b/controllers/notificationsController.js
@@ -1,7 +1,7 @@
 // controllers/meliNotificationController.js
 const Notification = require('../models/meliNotification');
 
-const INVENTORY_APP_URL = process.env.INVENTORY_APP_URL || 'https://inventory-app-f52ryed3da-uc.a.run.app';
+const INVENTORY_APP_URL = process.env.INVENTORY_APP_URL || 'https://inventory-app-713792767554.us-central1.run.app';
 const INVENTORY_API_KEY = process.env.INVENTORY_API_KEY || '';
 
 /**

--- a/models/asinCatalogMapping.js
+++ b/models/asinCatalogMapping.js
@@ -49,7 +49,12 @@ const asinCatalogMappingSchema = new Schema({
     },
     itemIds: [{
         type: String
-    }]
+    }],
+    asin: { type: String, default: null },
+    identifiers: [{ type: String }],
+    catalogIdentifier: { type: String, default: null },
+    image: { type: String, default: null },
+    title: { type: String, default: null }
 }, {
     collection: 'asincatalogmappings',
     timestamps: true


### PR DESCRIPTION
## Summary
- Al publicar un producto en MercadoLibre via `POST /api/mercadolibre/catalog-publish`, se crea automáticamente en el backend de intranet (sync-inventory)
- Si la creación en intranet falla, se cierra la publicación en ML como rollback y se retorna error
- Si el SKU ya existe en intranet (409), se trata como éxito sin rollback
- Se envían barcodes alternos (identifiers) como paso secundario (fallo no causa rollback)
- Campos agregados al schema `asinCatalogMapping`: `asin`, `identifiers`, `catalogIdentifier`, `image`, `title`
- URL de producción del backend de inventario actualizada en ambos controladores

## Test plan
- [ ] Publicar un producto con `mlCatalogId` de prueba y verificar creación en intranet (`GET /api/products/:sku`)
- [ ] Verificar que los barcodes alternos se agregan correctamente
- [ ] Simular fallo de intranet (API key inválida) y verificar que se cierra la publicación ML
- [ ] Verificar que si el SKU ya existe (409), no se hace rollback
- [ ] Verificar que `intranetProductCreated: true` aparece en la respuesta exitosa

🤖 Generated with [Claude Code](https://claude.com/claude-code)